### PR TITLE
Introducing ability to override API token in the task and improving logging

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,7 +1,0 @@
-<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
-    <extension>
-        <groupId>io.jenkins.tools.incrementals</groupId>
-        <artifactId>git-changelist-maven-extension</artifactId>
-        <version>1.3</version>
-    </extension>
-</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,0 @@
--Pconsume-incrementals
--Pmight-produce-incrementals
--Dchangelist.format=%d.v%s

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,6 @@
-buildPlugin()
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 11],
+])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,5 @@ buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 17],
-    [platform: 'windows', jdk: 11],
+//     [platform: 'windows', jdk: 11],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,4 @@ buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 17],
-    [platform: 'windows', jdk: 11],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,5 @@ buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 17],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,5 @@ buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 17],
-    [platform: 'windows', jdk: 17],
+    [platform: 'windows', jdk: 11],
 ])

--- a/README.md
+++ b/README.md
@@ -8,17 +8,19 @@ The Artifactz.io helps to track versions of the artifacts such as Jar(War/Ear) f
 In order to call the plugin method add the following to the pipeline:
 ```
    publishArtifact name: '<artifact name>',
-                    description: '<artifact description>',
-                    type: '<artifact type>',
-                    flow: '<flow name>',
-                    stage: '<stage>',
-                    stageDescription: '<stage description>',
-                    groupId: '<java artifact group Id>',
-                    artifactId: '<java artifact name, i.e. artifact Id>',
-                    version: "<version>"
+                   token: '<optional API token>',
+                   description: '<artifact description>',
+                   type: '<artifact type>',
+                   flow: '<flow name>',
+                   stage: '<stage>',
+                   stageDescription: '<stage description>',
+                   groupId: '<java artifact group Id>',
+                   artifactId: '<java artifact name, i.e. artifact Id>',
+                   version: "<version>"
                     
 // or                     
    step([$class: 'PublishArtifactVersionBuildStep',
+                        token: '<optional API token>',
                         name: '<artifact name>',
                         description: '<artifact description>',
                         type: '<artifact type>',
@@ -29,23 +31,26 @@ In order to call the plugin method add the following to the pipeline:
                         artifactId: '<java artifact name, i.e. artifact Id>',
                         version: "<version>"])
 ```
-Parameter | Description | Notes
----|---|---
-stage | The SDLC stage | The stage in the process where the version in question is being deployed
-stageDescription | The SDLC stage description | The above stage description (optional)
-name | Artifact Name | A unique name that identifies an artifact, e.g. artifactor-plugin
-description | Artifact Description | An artifact description (optional)
-type | An artifact type | Allowed values 'JAR', 'WAR', 'EAR', 'DockerImage'
-flow | The Flow name | The name of the flow if any, which the above stage is associated with. Bear in mind that stage can be associated with the number of flows or it could be used without association with the flow (optional)
-groupId | Java Group Id | The maven group Id (mandatory for Java artifacts, optional for the others)
-artifactId | Java Artifact Id | The maven artifact name (mandatory for Java artifacts, optional for the others)
-version | A version | The version of the artifact
+
+| Parameter        | Description                | Notes                                                                                                                                                                                                      |
+|------------------|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| token            | Artifactz.io API token     | The optional token with 'urn:artifactor:write' scope                                                                                                                                                       |
+| stage            | The SDLC stage             | The stage in the process where the version in question is being deployed                                                                                                                                   |
+| stageDescription | The SDLC stage description | The above stage description (optional)                                                                                                                                                                     |
+| name             | Artifact Name              | A unique name that identifies an artifact, e.g. artifactor-plugin                                                                                                                                          |
+| description      | Artifact Description       | An artifact description (optional)                                                                                                                                                                         |
+| type             | An artifact type           | Allowed values 'JAR', 'WAR', 'EAR', 'DockerImage'                                                                                                                                                          |
+| flow             | The Flow name              | The name of the flow if any, which the above stage is associated with. Bear in mind that stage can be associated with the number of flows or it could be used without association with the flow (optional) |
+| groupId          | Java Group Id              | The maven group Id (mandatory for Java artifacts, optional for the others)                                                                                                                                 |
+| artifactId       | Java Artifact Id           | The maven artifact name (mandatory for Java artifacts, optional for the others)                                                                                                                            |
+| version          | A version                  | The version of the artifact                                                                                                                                                                                |
 
 Any parameters can include variables.
 
 For example:
 ```
    step([$class: 'PublishArtifactVersionBuildStep',
+                        token: "${ARTIFACTZ_TOKEN}",
                         name: 'document-manager-ui',
                         type: 'DockerImage',
                         stage: 'uat',
@@ -62,26 +67,30 @@ To push artifact through the flow use the following step. If successful, the ste
 specified variable.
 ```
    step([$class: 'PushArtifactVersionBuildStep',
+                        token: '<optional API token>', 
                         name: '<artifact name>',
                         stage: '<stage>',
                         version: "<version>",
                         variableName: '<name of the variable to store pushed version>'])
 // or
-   def version = pushArtifact name: '<artifact name>',
-                                stage: '<stage>',
-                                version: "<version>"
+   def version = pushArtifact token: '<optional API token>', 
+                              name: '<artifact name>',
+                              stage: '<stage>',
+                              version: "<version>"
 ```
 
-Parameter | Description | Notes
----|---|---
-name | Artifact name | The name of the artifact to push, e.g. artifactor-plugin
-stage | The SDLC stage | The stage in the process from where the version will be pushed
-version | Artifact version | The artifact version to push (optional, if omitted the current version at the stage will be pushed)
-variableName | Variable Name | The variable name where the pushed version will be stored, default ARTIFACTZ_VERSION
+| Parameter    | Description            | Notes                                                                                               |
+|--------------|------------------------|-----------------------------------------------------------------------------------------------------|
+| token        | Artifactz.io API token | The optional token with 'urn:artifactor:write' scope                                                |
+| name         | Artifact name          | The name of the artifact to push, e.g. artifactor-plugin                                            |
+| stage        | The SDLC stage         | The stage in the process from where the version will be pushed                                      |
+| version      | Artifact version       | The artifact version to push (optional, if omitted the current version at the stage will be pushed) |
+| variableName | Variable Name          | The variable name where the pushed version will be stored, default ARTIFACTZ_VERSION                |
 
 For example:
 ```
    step([$class: 'PushArtifactVersionBuildStep',
+                        token: "${ARTIFACTZ_TOKEN}",                   
                         name: 'document-manager-ui',
                         stage: 'uat',
                         version: "1.0.0.${BUILD_NUMBER}"])
@@ -93,16 +102,17 @@ For example:
 
 In order to use the artifact retrieval function of the plugin the following step can be used:
 ```
-    def result = retrieveArtifacts stage: '<stage>', names: ['<artifact name>']
+    def result = retrieveArtifacts token: '<optional API token>', stage: '<stage>', names: ['<artifact name>']
 ```
-Parameter | Description | Notes
----|---|---
-stage | The SDLC stage | The stage in the process where the version in question is being deployed
-names | The array of the artifact names | e.g. artifactor-plugin
+| Parameter | Description                     | Notes                                                                    |
+|-----------|---------------------------------|--------------------------------------------------------------------------|
+| token     | Artifactz.io API token          | The optional token with 'urn:artifactor:read' scope                      |
+| stage     | The SDLC stage                  | The stage in the process where the version in question is being deployed |
+| names     | The array of the artifact names | e.g. artifactor-plugin                                                   |
 
 For example:
 ```
-    def result = retrieveArtifacts stage: 'uat', names: ['document-manager-ui']
+    def result = retrieveArtifacts token: "${ARTIFACTZ_TOKEN}", stage: 'uat', names: ['document-manager-ui']
 ```
 
 ## Testing

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.32</version>
+        <version>4.62</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -29,17 +29,17 @@
         </license>
     </licenses>
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <!-- Dependency versions -->
-        <jenkins.version>2.289.1</jenkins.version>
-        <jenkins-test-harness.version>2.34</jenkins-test-harness.version>
-        <groovy.version>2.4.17</groovy.version>
-        <junit.version>4.12</junit.version>
-        <jenkins-pipeline-unit.version>1.1</jenkins-pipeline-unit.version>
-        <groovy-eclipse-compiler.version>3.5.0-01</groovy-eclipse-compiler.version>
-        <java.level>8</java.level>
-        <revision>1.1.0</revision>
+        <jenkins.version>2.375.4</jenkins.version>
+<!--        <jenkins-test-harness.version>1954.v2e3fd5465b_a_6</jenkins-test-harness.version>-->
+        <groovy.version>2.4.21</groovy.version>
+<!--        <junit.version>4.12</junit.version>-->
+        <jenkins-pipeline-unit.version>1.17</jenkins-pipeline-unit.version>
+<!--        <groovy-eclipse-compiler.version>3.5.0-01</groovy-eclipse-compiler.version>-->
+<!--        <java.level>11</java.level>-->
+        <revision>1.2.0</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <connectorHost />
         <jenkins.host.address />
@@ -56,15 +56,15 @@
 <!--            <artifactId>maven-hpi-plugin</artifactId>-->
 <!--            <version>3.5</version>-->
 <!--        </dependency>-->
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>credentials</artifactId>
-            <version>2.3.19</version>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.jenkins-ci.plugins</groupId>-->
+<!--            <artifactId>credentials</artifactId>-->
+<!--            <version>1236.v31e44e6060c0</version>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>plain-credentials</artifactId>
-            <version>1.7</version>
+            <version>143.v1b_df8b_d3b_e48</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -74,27 +74,27 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.13.1</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.1</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.22</version>
+            <version>324.va_f5d6774f3a_d</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.23</version>
+            <version>639.v6eca_cd8c04a_a_</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <version>4.5.10-2.0</version>
+            <version>4.5.14-150.v7a_b_9d17134a_5</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -104,37 +104,37 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.87</version>
+            <version>3659.v582dc37621d8</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.40</version>
+            <version>1284.v2fe8ed4573d4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.23</version>
+            <version>1017.vb_45b_302f0cea_</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.37</version>
+            <version>1246.v5524618ea_097</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.40</version>
+            <version>1208.v0cc7c6e0da_9e</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>3.7</version>
+            <version>839.v35e2736cfd5c</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.powermock/powermock-core -->
@@ -161,13 +161,13 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.12.6</version>
+            <version>1.14.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy-agent</artifactId>
-            <version>1.12.6</version>
+            <version>1.14.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -195,22 +195,22 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.32</version>
+            <version>2.0.7</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.32</version>
+            <version>2.0.7</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
-            <version>1.7.32</version>
+            <version>2.0.7</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.32</version>
+            <version>2.0.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -221,7 +221,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
+            <version>4.5.14</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -234,13 +234,13 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>script-security</artifactId>
-                <version>1.75</version>
+                <version>1244.ve463715a_f89c</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>scm-api</artifactId>
-                <version>2.6.4</version>
+                <version>667.v8b_6e07cdc7f2</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
@@ -260,6 +260,9 @@
                         <jenkins.host.address>${jenkins.host.address}</jenkins.host.address>
                         <slaveAgentPort>${slaveAgentPort}</slaveAgentPort>
                     </systemPropertyVariables>
+                    <argLine>
+                        --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED
+                    </argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -272,6 +275,7 @@
                         <hudson.slaves.NodeProvisioner.MARGIN0>0.85</hudson.slaves.NodeProvisioner.MARGIN0>
                         <jenkins.host.address>${jenkins.host.address}</jenkins.host.address>
                     </systemProperties>
+                    <minimumJavaVersion>11</minimumJavaVersion>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,9 @@
                         --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED
                     </argLine>
                     <forkCount>1</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <threadCount>1</threadCount>
+                    <parallel>suites</parallel>
                     <shutdown>kill</shutdown>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
     <artifactId>artifactz</artifactId>
     <version>${revision}-${changelist}</version>
     <name>Artifactz.io Plugin</name>
-    <description>This plugin allows to exchange artifact details between pipeline or freestyle project Artifactz.io Web Service</description>
     <url>https://github.com/jenkinsci/artifactz-plugin</url>
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,6 @@
 <!--        <java.level>11</java.level>-->
         <revision>1.2.0</revision>
         <changelist>999999-SNAPSHOT</changelist>
-        <connectorHost />
-        <jenkins.host.address />
-        <slaveAgentPort />
     </properties>
     <dependencies>
 <!--        <dependency>-->
@@ -253,15 +250,12 @@
                     <systemPropertyVariables>
                         <hudson.slaves.NodeProvisioner.initialDelay>0</hudson.slaves.NodeProvisioner.initialDelay>
                         <hudson.slaves.NodeProvisioner.recurrencePeriod>3000</hudson.slaves.NodeProvisioner.recurrencePeriod>
-                        <!-- listen in this interface for connections from kubernetes pods -->
-                        <connectorHost>${connectorHost}</connectorHost>
-                        <!-- have pods connect to this address for Jenkins -->
-                        <jenkins.host.address>${jenkins.host.address}</jenkins.host.address>
-                        <slaveAgentPort>${slaveAgentPort}</slaveAgentPort>
                     </systemPropertyVariables>
                     <argLine>
                         --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED
                     </argLine>
+                    <forkCount>1</forkCount>
+                    <shutdown>kill</shutdown>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,14 @@
     <version>${revision}-${changelist}</version>
     <name>Artifactz.io Plugin</name>
     <description>This plugin allows to exchange artifact details between pipeline or freestyle project Artifactz.io Web Service</description>
-    <url>https://artifactz.io</url>
+    <url>https://github.com/jenkinsci/artifactz-plugin</url>
+    <developers>
+        <developer>
+            <id>ikolomiyets</id>
+            <name>Igor Kolomiyets</name>
+            <email>igor.kolomiyets@iktech.io</email>
+        </developer>
+    </developers>
     <packaging>hpi</packaging>
     <licenses>
         <license>
@@ -209,7 +216,7 @@
         <dependency>
             <groupId>io.iktech</groupId>
             <artifactId>artifactz-client</artifactId>
-            <version>1.1.2</version>
+            <version>1.1.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/io/iktech/jenkins/plugins/artifactz/ArtifactVersionPublisher.java
+++ b/src/main/java/io/iktech/jenkins/plugins/artifactz/ArtifactVersionPublisher.java
@@ -178,7 +178,7 @@ public class ArtifactVersionPublisher extends Builder implements SimpleBuildStep
             client.publishArtifact(expandedStage, expandedStageDescription, expandedName, expandedDescription, this.getFlow(), this.getType(), expandedGroupId, expandedArtifactId, expandedVersion);
             taskListener.getLogger().println("Successfully patched artifact version");
         } catch (ClientException e) {
-            ServiceHelper.interruptExecution(run, taskListener, e.getMessage());
+            ServiceHelper.interruptExecution(run, taskListener, "Error while publishing artifact version", e);
             throw new AbortException(e.getMessage());
         }
     }

--- a/src/main/java/io/iktech/jenkins/plugins/artifactz/ArtifactVersionPusher.java
+++ b/src/main/java/io/iktech/jenkins/plugins/artifactz/ArtifactVersionPusher.java
@@ -116,7 +116,7 @@ public class ArtifactVersionPusher extends Builder implements SimpleBuildStep {
             run.addAction(new InjectVariable(variableName, pushedVersion));
             taskListener.getLogger().println("Successfully pushed artifact version");
         } catch (ClientException e) {
-            ServiceHelper.interruptExecution(run, taskListener, e.getMessage());
+            ServiceHelper.interruptExecution(run, taskListener, "Error while pushing artifact version", e);
             throw new AbortException(e.getMessage());
         }
     }

--- a/src/main/java/io/iktech/jenkins/plugins/artifactz/PublishArtifactVersionBuildStep.java
+++ b/src/main/java/io/iktech/jenkins/plugins/artifactz/PublishArtifactVersionBuildStep.java
@@ -186,7 +186,7 @@ public class PublishArtifactVersionBuildStep extends Builder implements SimpleBu
             client.publishArtifact(expandedStage, expandedStageDescription, expandedName, expandedDescription, this.getFlow(), this.getType(), expandedGroupId, expandedArtifactId, expandedVersion);
             taskListener.getLogger().println("Successfully patched artifact version");
         } catch (ClientException e) {
-            ServiceHelper.interruptExecution(run, taskListener, e.getMessage());
+            ServiceHelper.interruptExecution(run, taskListener, "Error while publishing artifact version", e);
             throw new AbortException(e.getMessage());
         }
     }

--- a/src/main/java/io/iktech/jenkins/plugins/artifactz/PushArtifactStep.java
+++ b/src/main/java/io/iktech/jenkins/plugins/artifactz/PushArtifactStep.java
@@ -103,7 +103,12 @@ public class PushArtifactStep extends Step {
             TaskListener taskListener = getContext().get(TaskListener.class);
 
             PrintStream l = taskListener.getLogger();
-            l.println("Pushing artifact '" + this.name + "' at the stage '" + this.stage + "'");
+            l.println("Pushing the artifact version '" + this.name + ":" + this.version + "' at the stage '" + this.stage + "'");
+            l.println("Performing PUT request to  to the Artifactor instance @" + Configuration.get().getServerUrl());
+            l.println("Artifact details:");
+            l.println("  name: " + this.name);
+            l.println("  stage: " + this.stage);
+            l.println("  version: " + this.version);
 
             try {
                 ServiceClient client = ServiceHelper.getClient(taskListener, ServiceHelper.getToken(run, taskListener, this.token));
@@ -113,7 +118,7 @@ public class PushArtifactStep extends Step {
             } catch (ClientException e) {
                 logger.error("Error while pushing artifact version", e);
                 String errorMessage = "Error while pushing artifact version: " + e.getMessage();
-                ServiceHelper.interruptExecution(run, taskListener, errorMessage);
+                ServiceHelper.interruptExecution(run, taskListener, "Error while pushing artifact version", e);
                 throw new AbortException(errorMessage);
             }
         }

--- a/src/main/java/io/iktech/jenkins/plugins/artifactz/PushArtifactStep.java
+++ b/src/main/java/io/iktech/jenkins/plugins/artifactz/PushArtifactStep.java
@@ -22,15 +22,29 @@ import java.util.Set;
 
 public class PushArtifactStep extends Step {
     private static final Logger logger = LoggerFactory.getLogger(PushArtifactStep.class);
+    private String token;
+
     private String stage;
+
     private String name;
+
     private String version;
 
     @DataBoundConstructor
-    public PushArtifactStep(String stage, String name, String version, String variable) {
+    public PushArtifactStep(String token, String stage, String name, String version, String variable) {
+        this.token = token;
         this.stage = stage;
         this.name = name;
         this.version = version;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    @DataBoundSetter
+    public void setToken(String token) {
+        this.token = token;
     }
 
     public String getStage() {
@@ -62,18 +76,23 @@ public class PushArtifactStep extends Step {
 
     @Override
     public StepExecution start(StepContext context) throws Exception {
-        return new PushArtifactStep.Execution(stage, name, version, context);
+        return new PushArtifactStep.Execution(this.token, this.stage, this.name, this.version, context);
     }
 
     private static final class Execution extends SynchronousNonBlockingStepExecution<String> {
         private static final long serialVersionUID = 7351377150717079126L;
 
+        private final String token;
+
         private final String stage;
+
         private final String name;
+
         private final String version;
 
-        Execution(String stage, String name, String version, StepContext context) {
+        Execution(String token, String stage, String name, String version, StepContext context) {
             super(context);
+            this.token = token;
             this.stage = stage;
             this.name = name;
             this.version = version;
@@ -86,20 +105,8 @@ public class PushArtifactStep extends Step {
             PrintStream l = taskListener.getLogger();
             l.println("Pushing artifact '" + this.name + "' at the stage '" + this.stage + "'");
 
-            String credentialsId = Configuration.get().getCredentialsId();
-            if (credentialsId == null) {
-                ServiceHelper.interruptExecution(run, taskListener, "Artifactz access credentials are not defined. Cannot continue.");
-                throw new AbortException("Artifactz access credentials are not defined. Cannot continue.");
-            }
-
-            StringCredentials token = CredentialsProvider.findCredentialById(credentialsId, StringCredentials.class, run);
-            if (token == null) {
-                ServiceHelper.interruptExecution(run, taskListener, "Could not find specified credentials. Cannot continue.");
-                throw new AbortException("Could not find specified credentials. Cannot continue.");
-            }
-
             try {
-                ServiceClient client = ServiceHelper.getClient(taskListener, token.getSecret().getPlainText());
+                ServiceClient client = ServiceHelper.getClient(taskListener, ServiceHelper.getToken(run, taskListener, this.token));
                 String v = client.pushArtifact(this.stage, this.name, this.version);
                 taskListener.getLogger().println("Successfully pushed artifact versions");
                 return v;

--- a/src/main/java/io/iktech/jenkins/plugins/artifactz/PushArtifactVersionBuildStep.java
+++ b/src/main/java/io/iktech/jenkins/plugins/artifactz/PushArtifactVersionBuildStep.java
@@ -116,7 +116,7 @@ public class PushArtifactVersionBuildStep extends Builder implements SimpleBuild
             run.addAction(new InjectVariable(variableName, pushedVersion));
             taskListener.getLogger().println("Successfully pushed artifact version");
         } catch (ClientException e) {
-            ServiceHelper.interruptExecution(run, taskListener, e.getMessage());
+            ServiceHelper.interruptExecution(run, taskListener, "Error while pushing artifact version", e);
             throw new AbortException(e.getMessage());
         }
     }

--- a/src/main/java/io/iktech/jenkins/plugins/artifactz/RetrieveArtifactsBuildStep.java
+++ b/src/main/java/io/iktech/jenkins/plugins/artifactz/RetrieveArtifactsBuildStep.java
@@ -124,7 +124,7 @@ public class RetrieveArtifactsBuildStep extends Builder implements SimpleBuildSt
         } catch (ClientException e) {
             logger.error("Error while retrieving artifact versions", e);
             String errorMessage = "Error while retrieving artifact versions: " + e.getMessage();
-            ServiceHelper.interruptExecution(run, taskListener, errorMessage);
+            ServiceHelper.interruptExecution(run, taskListener, "Error while retrieving artifact versions", e);
             throw new AbortException(errorMessage);
         }
     }

--- a/src/main/java/io/iktech/jenkins/plugins/artifactz/RetrieveArtifactsStep.java
+++ b/src/main/java/io/iktech/jenkins/plugins/artifactz/RetrieveArtifactsStep.java
@@ -23,13 +23,26 @@ import java.util.stream.Collectors;
 
 public class RetrieveArtifactsStep extends Step {
     private static Logger logger = LoggerFactory.getLogger(RetrieveArtifactsStep.class);
+    private String token;
+
     private String stage;
+
     private List<String> names;
 
     @DataBoundConstructor
-    public RetrieveArtifactsStep(String stage, List<String> names) {
+    public RetrieveArtifactsStep(String token, String stage, List<String> names) {
+        this.token = token;
         this.stage = stage;
         this.names = names;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    @DataBoundSetter
+    public void setToken(String token) {
+        this.token = token;
     }
 
     public String getStage() {
@@ -52,17 +65,21 @@ public class RetrieveArtifactsStep extends Step {
 
     @Override
     public StepExecution start(StepContext context) throws Exception {
-        return new Execution(stage, names, context);
+        return new Execution(this.token, this.stage, this.names, context);
     }
 
     private static final class Execution extends SynchronousNonBlockingStepExecution<Map<String, String>> {
         private static final long serialVersionUID = 6190377462479580850L;
 
+        private final String token;
+
         private final String stage;
+
         private final List<String> names;
 
-        Execution(String stage, List<String> names, StepContext context) {
+        Execution(String token, String stage, List<String> names, StepContext context) {
             super(context);
+            this.token = token;
             this.stage = stage;
             this.names = names;
         }
@@ -75,20 +92,8 @@ public class RetrieveArtifactsStep extends Step {
             PrintStream l = taskListener.getLogger();
             l.println("Retrieving versions of the following artifacts at the stage '" + this.stage + "'");
 
-            String credentialsId = Configuration.get().getCredentialsId();
-            if (credentialsId == null) {
-                ServiceHelper.interruptExecution(run, taskListener, "Artifactz access credentials are not defined. Cannot continue.");
-                throw new AbortException("Artifactz access credentials are not defined. Cannot continue.");
-            }
-
-            StringCredentials token = CredentialsProvider.findCredentialById(credentialsId, StringCredentials.class, run);
-            if (token == null) {
-                ServiceHelper.interruptExecution(run, taskListener, "Could not find specified credentials. Cannot continue.");
-                throw new AbortException("Could not find specified credentials. Cannot continue.");
-            }
-
             try {
-                ServiceClient client = ServiceHelper.getClient(taskListener, token.getSecret().getPlainText());
+                ServiceClient client = ServiceHelper.getClient(taskListener, ServiceHelper.getToken(run, taskListener, this.token));
                 io.artifactz.client.model.Stage stage = client.retrieveVersions(this.stage, this.names.toArray(new String[0]));
                 logger.info("Content has been converted to the object");
                 if (stage.getArtifacts() != null) {

--- a/src/main/java/io/iktech/jenkins/plugins/artifactz/RetrieveArtifactsStep.java
+++ b/src/main/java/io/iktech/jenkins/plugins/artifactz/RetrieveArtifactsStep.java
@@ -107,7 +107,7 @@ public class RetrieveArtifactsStep extends Step {
             } catch (ClientException e) {
                 logger.error("Error while retrieving artifact versions", e);
                 String errorMessage = "Error while retrieving artifact versions: " + e.getMessage();
-                ServiceHelper.interruptExecution(run, taskListener, errorMessage);
+                ServiceHelper.interruptExecution(run, taskListener, "Error while retrieving artifact versions", e);
                 throw new AbortException(errorMessage);
             }
         }

--- a/src/main/java/io/iktech/jenkins/plugins/artifactz/ServiceHelper.java
+++ b/src/main/java/io/iktech/jenkins/plugins/artifactz/ServiceHelper.java
@@ -40,6 +40,28 @@ public class ServiceHelper {
         }
     }
 
+    public static void interruptExecution(@Nonnull Run<?, ?> run, @Nonnull TaskListener taskListener, String prefix, Throwable e) {
+        boolean firstLine = true;
+
+
+        while (e != null) {
+            if (e.getMessage() != null) {
+                taskListener.fatalError((!firstLine ? "    " : (prefix != null ? prefix + ": " : "")) + e.getMessage());
+            }
+
+            if (firstLine) {
+                firstLine = false;
+            }
+
+            e = e.getCause();
+        }
+
+        Executor executor = run.getExecutor();
+        if (executor != null) {
+            executor.interrupt(Result.FAILURE);
+        }
+    }
+
     public static ServiceClient getClient(TaskListener taskListener, String token) throws ClientException {
         String proxyUsername = null;
         String proxyPassword = null;

--- a/src/main/java/io/iktech/jenkins/plugins/artifactz/ServiceHelper.java
+++ b/src/main/java/io/iktech/jenkins/plugins/artifactz/ServiceHelper.java
@@ -3,6 +3,7 @@ package io.iktech.jenkins.plugins.artifactz;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
+import hudson.AbortException;
 import hudson.model.Executor;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -19,6 +20,7 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 import javax.annotation.Nonnull;
 import java.net.MalformedURLException;
@@ -103,5 +105,25 @@ public class ServiceHelper {
         }
 
         return proxyHttpHost;
+    }
+
+    public static String getToken(Run<?, ?> run, TaskListener taskListener, String inlineToken) throws AbortException {
+        if (inlineToken == null) {
+            String credentialsId = Configuration.get().getCredentialsId();
+            if (credentialsId == null) {
+                ServiceHelper.interruptExecution(run, taskListener, "Artifactz access credentials are not defined. Cannot continue.");
+                throw new AbortException("Artifactz access credentials are not defined. Cannot continue.");
+            }
+
+            StringCredentials token = CredentialsProvider.findCredentialById(credentialsId, StringCredentials.class, run);
+            if (token == null) {
+                ServiceHelper.interruptExecution(run, taskListener, "Could not find specified credentials. Cannot continue.");
+                throw new AbortException("Could not find specified credentials. Cannot continue.");
+            }
+
+            return token.getSecret().getPlainText();
+        }
+
+        return inlineToken;
     }
 }

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    This plugin allows to exchange artifact details between pipeline or freestyle project Artifactz.io Web Service
+</div>

--- a/src/test/java/io/iktech/jenkins/plugin/artifactz/ArtifactVersionPublisherTest.java
+++ b/src/test/java/io/iktech/jenkins/plugin/artifactz/ArtifactVersionPublisherTest.java
@@ -100,7 +100,7 @@ public class ArtifactVersionPublisherTest {
         System.out.println(build.getDisplayName() + " completed");
         // TODO: change this to use HtmlUnit
         String s = FileUtils.readFileToString(build.getLogFile());
-        assertThat(s, containsString("FATAL: Test error message"));
+        assertThat(s, containsString("FATAL: Error while publishing artifact version: Test error message"));
     }
 
     @Test

--- a/src/test/java/io/iktech/jenkins/plugin/artifactz/ArtifactVersionPusherTest.java
+++ b/src/test/java/io/iktech/jenkins/plugin/artifactz/ArtifactVersionPusherTest.java
@@ -88,7 +88,7 @@ public class ArtifactVersionPusherTest {
         System.out.println(build.getDisplayName() + " completed");
         // TODO: change this to use HtmlUnit
         String s = FileUtils.readFileToString(build.getLogFile());
-        assertThat(s, containsString("FATAL: Test error message"));
+        assertThat(s, containsString("FATAL: Error while pushing artifact version: Test error message"));
     }
 
     @Test

--- a/src/test/java/io/iktech/jenkins/plugin/artifactz/PublishArtifactStepTest.java
+++ b/src/test/java/io/iktech/jenkins/plugin/artifactz/PublishArtifactStepTest.java
@@ -47,7 +47,8 @@ public class PublishArtifactStepTest {
 
     @Test
     public void gettersAndSettersTest() throws Exception {
-        PublishArtifactStep test = new PublishArtifactStep(null, null, null, null, null, null, null, null, null);
+        PublishArtifactStep test = new PublishArtifactStep(null, null, null, null, null, null, null, null, null, null);
+        test.setToken("72bdcd31-03d0-47c6-bfa2-5455b44feb44");
         test.setName("test-artifact");
         test.setDescription("Test Artifact");
         test.setStage("Development");
@@ -57,6 +58,7 @@ public class PublishArtifactStepTest {
         test.setGroupId("io.iktech.test");
         test.setArtifactId("test-artifact");
         test.setVersion("1.0.0");
+        assertEquals("72bdcd31-03d0-47c6-bfa2-5455b44feb44", test.getToken());
         assertEquals("test-artifact", test.getName());
         assertEquals("Test Artifact", test.getDescription());
         assertEquals("Development", test.getStage());
@@ -76,6 +78,22 @@ public class PublishArtifactStepTest {
         project.setDefinition(new CpsFlowDefinition("" +
                 "node {" +
                 "  publishArtifact stage: 'Development', name: 'test-artifact', type: 'DockerImage', version: '1.0.0'\n" +
+                "}", true));
+
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        System.out.println(build.getDisplayName() + " completed");
+        String s = FileUtils.readFileToString(build.getLogFile());
+        assertThat(s, containsString("Successfully published artifact"));
+    }
+
+    @Test
+    public void publishArtifactWithTokensSuccessTest() throws Exception {
+        TestHelper.setupClient();
+
+        WorkflowJob project = j.createProject(WorkflowJob.class);
+        project.setDefinition(new CpsFlowDefinition("" +
+                "node {" +
+                "  publishArtifact token: 'f10b9da8-7d08-4fe4-9e45-e88d4e126132', stage: 'Development', name: 'test-artifact', type: 'DockerImage', version: '1.0.0'\n" +
                 "}", true));
 
         WorkflowRun build = project.scheduleBuild2(0).get();

--- a/src/test/java/io/iktech/jenkins/plugin/artifactz/PublishArtifactStepTest.java
+++ b/src/test/java/io/iktech/jenkins/plugin/artifactz/PublishArtifactStepTest.java
@@ -120,6 +120,6 @@ public class PublishArtifactStepTest {
         WorkflowRun build = project.scheduleBuild2(0).get();
         System.out.println(build.getDisplayName() + " completed");
         String s = FileUtils.readFileToString(build.getLogFile());
-        assertThat(s, containsString("Error while publishing artifact: test exception"));
+        assertThat(s, containsString("FATAL: Error while publishing artifact version: test exception"));
     }
 }

--- a/src/test/java/io/iktech/jenkins/plugin/artifactz/PublishArtifactVersionBuildStepTest.java
+++ b/src/test/java/io/iktech/jenkins/plugin/artifactz/PublishArtifactVersionBuildStepTest.java
@@ -127,7 +127,7 @@ public class PublishArtifactVersionBuildStepTest {
         System.out.println(build.getDisplayName() + " completed");
         // TODO: change this to use HtmlUnit
         String s = FileUtils.readFileToString(build.getLogFile());
-        assertThat(s, containsString("FATAL: Test error message"));
+        assertThat(s, containsString("FATAL: Error while publishing artifact version: Test error message"));
     }
 
     @Test

--- a/src/test/java/io/iktech/jenkins/plugin/artifactz/PublishArtifactVersionBuildStepTest.java
+++ b/src/test/java/io/iktech/jenkins/plugin/artifactz/PublishArtifactVersionBuildStepTest.java
@@ -47,7 +47,34 @@ public class PublishArtifactVersionBuildStepTest {
         configuration.setServerUrl("http://localhost:5002");
         configuration.doFillCredentialsIdItems(Jenkins.get(), null, "test");
         configuration.setCredentialsId("test");
-        PublishArtifactVersionBuildStep step = new PublishArtifactVersionBuildStep(null, null, null, null, null, null, null, null, null);
+        PublishArtifactVersionBuildStep step = new PublishArtifactVersionBuildStep(null, null, null, null, null, null, null, null, null, null);
+        step.setName("test-artifact");
+        step.setStage("Development");
+        step.setStageDescription("Development stage");
+        step.setDescription("Test Artifact");
+        step.setType("JAR");
+        step.setFlow("Default");
+        step.setGroupId("io.iktech.test");
+        step.setArtifactId("test.artifact");
+        step.setVersion("1.0.0");
+        project.getBuildersList().add(step);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        System.out.println(build.getDisplayName() + " completed");
+        // TODO: change this to use HtmlUnit
+        String s = FileUtils.readFileToString(build.getLogFile());
+        assertThat(s, containsString("Successfully patched artifact version"));
+    }
+
+    @Test
+    public void publishArtifactWithTokenSuccessTest() throws Exception {
+        TestHelper.setupClient();
+        FreeStyleProject project = j.createFreeStyleProject();
+        Configuration configuration = Configuration.get();
+        configuration.setServerUrl("http://localhost:5002");
+        configuration.doFillCredentialsIdItems(Jenkins.get(), null, "test");
+        configuration.setCredentialsId("test");
+        PublishArtifactVersionBuildStep step = new PublishArtifactVersionBuildStep(null, null, null, null, null, null, null, null, null, null);
+        step.setToken("94266b76-884a-408d-b725-7100ae9767f3");
         step.setName("test-artifact");
         step.setStage("Development");
         step.setStageDescription("Development stage");
@@ -73,7 +100,7 @@ public class PublishArtifactVersionBuildStepTest {
         configuration.setServerUrl("http://localhost:5002");
         configuration.doFillCredentialsIdItems(Jenkins.get(), null, "test");
         configuration.setCredentialsId("test");
-        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep("test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
+        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep(null, "test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
         publisher.setFlow("Default");
         publisher.setType("WAR");
         project.getBuildersList().add(publisher);
@@ -95,7 +122,7 @@ public class PublishArtifactVersionBuildStepTest {
         configuration.setServerUrl("http://localhost:5002");
         configuration.doFillCredentialsIdItems(Jenkins.get(), null, "test");
         configuration.setCredentialsId("test");
-        project.getBuildersList().add(new PublishArtifactVersionBuildStep("test-artifact", null, "JAR", "io.iktech.test", "test.artifact", "Development", null, null, "1.0.0"));
+        project.getBuildersList().add(new PublishArtifactVersionBuildStep(null, "test-artifact", null, "JAR", "io.iktech.test", "test.artifact", "Development", null, null, "1.0.0"));
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         System.out.println(build.getDisplayName() + " completed");
         // TODO: change this to use HtmlUnit
@@ -105,13 +132,13 @@ public class PublishArtifactVersionBuildStepTest {
 
     @Test
     public void descriptorDisplayNameTest() throws Exception {
-        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep("test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
+        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep(null, "test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
         assertEquals("Send Artifact Version To Artifactor Web Service", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).getDisplayName());
     }
 
     @Test
     public void descriptorDoCheckNameTest() throws Exception {
-        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep("test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
+        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep(null, "test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
         assertEquals("OK", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckName("test").kind.name());
         assertEquals("ERROR", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckName("").kind.name());
         assertEquals("ERROR", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckName(null).kind.name());
@@ -120,7 +147,7 @@ public class PublishArtifactVersionBuildStepTest {
 
     @Test
     public void descriptorDoCheckStageTest() throws Exception {
-        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep("test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
+        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep(null, "test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
         assertEquals("OK", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckStage("test").kind.name());
         assertEquals("ERROR", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckStage("").kind.name());
         assertEquals("ERROR", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckStage(null).kind.name());
@@ -129,7 +156,7 @@ public class PublishArtifactVersionBuildStepTest {
 
     @Test
     public void descriptorDoCheckTypeTest() throws Exception {
-        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep("test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
+        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep(null, "test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
         assertEquals("OK", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckType("JAR").kind.name());
         assertEquals("ERROR", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckType("").kind.name());
         assertEquals("ERROR", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckType(null).kind.name());
@@ -138,7 +165,7 @@ public class PublishArtifactVersionBuildStepTest {
 
     @Test
     public void descriptorDoCheckGroupIdTest() throws Exception {
-        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep("test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
+        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep(null, "test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
         assertEquals("OK", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckGroupId("io.iktech", "JAR").kind.name());
         assertEquals("OK", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckGroupId("", "DockerImage").kind.name());
         assertEquals("ERROR", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckGroupId("", "JAR").kind.name());
@@ -148,7 +175,7 @@ public class PublishArtifactVersionBuildStepTest {
 
     @Test
     public void descriptorDoCheckArtifactIdTest() throws Exception {
-        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep("test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
+        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep(null, "test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
         assertEquals("OK", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckArtifactId("test", "JAR").kind.name());
         assertEquals("OK", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckArtifactId("", "DockerImage").kind.name());
         assertEquals("ERROR", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckArtifactId("", "JAR").kind.name());
@@ -158,7 +185,7 @@ public class PublishArtifactVersionBuildStepTest {
 
     @Test
     public void descriptorDoCheckVersionTest() throws Exception {
-        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep("test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
+        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep(null, "test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
         assertEquals("OK", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckVersion("1.0").kind.name());
         assertEquals("ERROR", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckVersion("").kind.name());
         assertEquals("ERROR", ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckVersion(null).kind.name());
@@ -167,7 +194,7 @@ public class PublishArtifactVersionBuildStepTest {
 
     @Test
     public void descriptorDoFillItemsTest() throws Exception {
-        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep("test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
+        PublishArtifactVersionBuildStep publisher = new PublishArtifactVersionBuildStep(null, "test-artifact", "Test Artifact", "JAR", "io.iktech.test", "test.artifact", "Development", "Defalt", "Development Stage", "1.0.0");
         ListBoxModel m = ((PublishArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doFillTypeItems(null);
         assertEquals(5, m.size());
         assertEquals("- none -", m.get(0).name);

--- a/src/test/java/io/iktech/jenkins/plugin/artifactz/PushArtifactStepTest.java
+++ b/src/test/java/io/iktech/jenkins/plugin/artifactz/PushArtifactStepTest.java
@@ -50,10 +50,12 @@ public class PushArtifactStepTest {
 
     @Test
     public void gettersAndSettersTest() throws Exception {
-        PushArtifactStep test = new PushArtifactStep(null, null, null, null);
+        PushArtifactStep test = new PushArtifactStep(null, null, null, null, null);
+        test.setToken("54156708-00ea-418d-b125-b5c3bf1a0e0a");
         test.setStage("Development");
         test.setName("test-artifact");
         test.setVersion("1.0.0");
+        assertEquals("54156708-00ea-418d-b125-b5c3bf1a0e0a", test.getToken());
         assertEquals("Development", test.getStage());
         assertEquals("test-artifact", test.getName());
         assertEquals("1.0.0", test.getVersion());
@@ -71,6 +73,28 @@ public class PushArtifactStepTest {
         project.setDefinition(new CpsFlowDefinition("" +
                 "node {" +
                 "  def version = pushArtifact stage: 'Development', name: 'test-artifact'\n" +
+                "  echo \"Version: ${version}\"\n" +
+                "}", true));
+
+        WorkflowRun build = project.scheduleBuild2(0).get();
+        System.out.println(build.getDisplayName() + " completed");
+        String s = FileUtils.readFileToString(build.getLogFile());
+        assertThat(s, containsString("Successfully pushed artifact versions"));
+        assertThat(s, containsString("Version: 1.0.0"));
+    }
+
+    @Test
+    public void pushArtifactWithTokenSuccessTest() throws Exception {
+        ServiceClient client = TestHelper.setupClient();
+
+        List<Version> artifacts = new ArrayList<>();
+
+        when(client.pushArtifact(eq("Development"), eq("test-artifact"), any())).thenReturn("1.0.0");
+
+        WorkflowJob project = j.createProject(WorkflowJob.class);
+        project.setDefinition(new CpsFlowDefinition("" +
+                "node {" +
+                "  def version = pushArtifact token: '9c9696fa-129c-49c3-93a8-2db0e6657f5e', stage: 'Development', name: 'test-artifact'\n" +
                 "  echo \"Version: ${version}\"\n" +
                 "}", true));
 

--- a/src/test/java/io/iktech/jenkins/plugin/artifactz/PushArtifactVersionBuildStepTest.java
+++ b/src/test/java/io/iktech/jenkins/plugin/artifactz/PushArtifactVersionBuildStepTest.java
@@ -57,7 +57,31 @@ public class PushArtifactVersionBuildStepTest {
         configuration.setCredentialsId("test");
         configuration.setProxy("http://proxy.iktech.io:3128");
         configuration.setProxyCredentialsId("proxy-test");
-        PushArtifactVersionBuildStep step = new PushArtifactVersionBuildStep(null, null, null, null);
+        PushArtifactVersionBuildStep step = new PushArtifactVersionBuildStep(null, null, null, null, null);
+        step.setName("test-artifact");
+        step.setStage("Development");
+        step.setVersion("1.0.0");
+        step.setVariableName("VERSION");
+        project.getBuildersList().add(step);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        System.out.println(build.getDisplayName() + " completed");
+        // TODO: change this to use HtmlUnit
+        String s = FileUtils.readFileToString(build.getLogFile());
+        assertThat(s, containsString("Successfully pushed artifact version"));
+    }
+    @Test
+    public void pushArtifactWithTokenSuccessTest() throws Exception {
+        TestHelper.setupClient();
+        FreeStyleProject project = j.createFreeStyleProject();
+        Configuration configuration = Configuration.get();
+        configuration.setServerUrl("http://localhost:5002");
+        configuration.doFillCredentialsIdItems(Jenkins.get(), null, "test");
+        configuration.doFillProxyCredentialsIdItems(Jenkins.get(), null, "proxy-test");
+        configuration.setCredentialsId("test");
+        configuration.setProxy("http://proxy.iktech.io:3128");
+        configuration.setProxyCredentialsId("proxy-test");
+        PushArtifactVersionBuildStep step = new PushArtifactVersionBuildStep(null, null, null, null, null);
+        step.setToken("191c06b9-8c01-47e9-996c-5f1c58851ca3");
         step.setName("test-artifact");
         step.setStage("Development");
         step.setVersion("1.0.0");
@@ -83,7 +107,7 @@ public class PushArtifactVersionBuildStepTest {
         configuration.setCredentialsId("test");
         configuration.setProxy("http://proxy.iktech.io:3128");
         configuration.setProxyCredentialsId("proxy-test");
-        project.getBuildersList().add(new PushArtifactVersionBuildStep("test-artifact", "Development", "1.0.0", null));
+        project.getBuildersList().add(new PushArtifactVersionBuildStep(null, "test-artifact", "Development", "1.0.0", null));
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         System.out.println(build.getDisplayName() + " completed");
         // TODO: change this to use HtmlUnit
@@ -93,13 +117,13 @@ public class PushArtifactVersionBuildStepTest {
 
     @Test
     public void descriptorDisplayNameTest() throws Exception {
-        PushArtifactVersionBuildStep publisher = new PushArtifactVersionBuildStep("test-artifact", "Development", "1.0.0", null);
+        PushArtifactVersionBuildStep publisher = new PushArtifactVersionBuildStep("test", "test-artifact", "Development", "1.0.0", null);
         assertEquals("Push Artifact Version to the next stage in the flow", ((PushArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).getDisplayName());
     }
 
     @Test
     public void descriptorDoCheckNameTest() throws Exception {
-        PushArtifactVersionBuildStep publisher = new PushArtifactVersionBuildStep("test-artifact", "Development", "1.0.0", null);
+        PushArtifactVersionBuildStep publisher = new PushArtifactVersionBuildStep(null, "test-artifact", "Development", "1.0.0", null);
         assertEquals("OK", ((PushArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckName("test").kind.name());
         assertEquals("ERROR", ((PushArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckName("").kind.name());
         assertEquals("ERROR", ((PushArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckName(null).kind.name());
@@ -108,7 +132,7 @@ public class PushArtifactVersionBuildStepTest {
 
     @Test
     public void descriptorDoCheckStageTest() throws Exception {
-        PushArtifactVersionBuildStep publisher = new PushArtifactVersionBuildStep("test-artifact", "Development", "1.0.0", null);
+        PushArtifactVersionBuildStep publisher = new PushArtifactVersionBuildStep(null, "test-artifact", "Development", "1.0.0", null);
         assertEquals("OK", ((PushArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckStage("test").kind.name());
         assertEquals("ERROR", ((PushArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckStage("").kind.name());
         assertEquals("ERROR", ((PushArtifactVersionBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckStage(null).kind.name());

--- a/src/test/java/io/iktech/jenkins/plugin/artifactz/PushArtifactVersionBuildStepTest.java
+++ b/src/test/java/io/iktech/jenkins/plugin/artifactz/PushArtifactVersionBuildStepTest.java
@@ -112,7 +112,7 @@ public class PushArtifactVersionBuildStepTest {
         System.out.println(build.getDisplayName() + " completed");
         // TODO: change this to use HtmlUnit
         String s = FileUtils.readFileToString(build.getLogFile());
-        assertThat(s, containsString("FATAL: Test error message"));
+        assertThat(s, containsString("FATAL: Error while pushing artifact version: Test error message"));
     }
 
     @Test

--- a/src/test/java/io/iktech/jenkins/plugin/artifactz/RetrieveArtifactsBuildStepTest.java
+++ b/src/test/java/io/iktech/jenkins/plugin/artifactz/RetrieveArtifactsBuildStepTest.java
@@ -67,7 +67,44 @@ public class RetrieveArtifactsBuildStepTest {
         name.setName("test-artifact");
         names.add(name);
 
-        RetrieveArtifactsBuildStep step = new RetrieveArtifactsBuildStep(names, "Development", null);
+        RetrieveArtifactsBuildStep step = new RetrieveArtifactsBuildStep(null, names, "Development", null);
+        step.setVariableName("ARTIFACT_VERSIONS");
+
+        project.getBuildersList().add(step);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        System.out.println(build.getDisplayName() + " completed");
+        // TODO: change this to use HtmlUnit
+        String s = FileUtils.readFileToString(build.getLogFile());
+        assertThat(s, containsString("Successfully retrieved artifact versions"));
+        EnvVars vars = build.getEnvironment();
+        assertNotNull(vars);
+        assertEquals("{\"test-artifact\":\"1.0.0\"}", vars.get("ARTIFACT_VERSIONS"));
+    }
+
+    @Test
+    public void retrieveArtifactWithTokenSuccessTest() throws Exception {
+        ServiceClient client = TestHelper.setupClient();
+
+        List<Version> artifacts = new ArrayList<>();
+
+        Version version = new Version("test-artifact", "Test Artifact", "DockerImage", null, null, "1.0.0");
+        artifacts.add(version);
+
+        Stage stage = new Stage("Development", artifacts);
+
+        when(client.retrieveVersions(eq("Development"), eq("test-artifact"))).thenReturn(stage);
+        FreeStyleProject project = j.createFreeStyleProject();
+        Configuration configuration = Configuration.get();
+        configuration.setServerUrl("http://localhost:5002");
+        configuration.doFillCredentialsIdItems(Jenkins.get(), null, "test");
+        configuration.setCredentialsId("test");
+        List<Name> names = new ArrayList<>();
+        Name name = new Name();
+        name.setName("test-artifact");
+        names.add(name);
+
+        RetrieveArtifactsBuildStep step = new RetrieveArtifactsBuildStep(null, names, "Development", null);
+        step.setToken("508c8d0d-79c4-4bec-be70-8e47de3a2be5");
         step.setVariableName("ARTIFACT_VERSIONS");
 
         project.getBuildersList().add(step);
@@ -103,7 +140,7 @@ public class RetrieveArtifactsBuildStepTest {
         name.setName("test-artifact");
         names.add(name);
 
-        project.getBuildersList().add(new RetrieveArtifactsBuildStep(names, "Development", null));
+        project.getBuildersList().add(new RetrieveArtifactsBuildStep("test", names, "Development", null));
         FreeStyleBuild build = project.scheduleBuild2(0).get();
         System.out.println(build.getDisplayName() + " completed");
         // TODO: change this to use HtmlUnit
@@ -132,7 +169,7 @@ public class RetrieveArtifactsBuildStepTest {
         name.setName("test-artifact");
         names.add(name);
 
-        RetrieveArtifactsBuildStep step = new RetrieveArtifactsBuildStep(names, "Development", "ARTIFACT_VERSIONS");
+        RetrieveArtifactsBuildStep step = new RetrieveArtifactsBuildStep(null, names, "Development", "ARTIFACT_VERSIONS");
         step.setNames(names);
         step.setStage("Development");
         step.setVariableName("ARTIFACT_VERSIONS");
@@ -163,7 +200,7 @@ public class RetrieveArtifactsBuildStepTest {
         name.setName("test-artifact");
         names.add(name);
 
-        RetrieveArtifactsBuildStep step = new RetrieveArtifactsBuildStep(names, "Development", null);
+        RetrieveArtifactsBuildStep step = new RetrieveArtifactsBuildStep(null, names, "Development", null);
         step.setNames(names);
         step.setStage("Development");
 
@@ -182,7 +219,7 @@ public class RetrieveArtifactsBuildStepTest {
         name.setName("test-artifact");
         names.add(name);
 
-        RetrieveArtifactsBuildStep publisher = new RetrieveArtifactsBuildStep(names, "Development", null);
+        RetrieveArtifactsBuildStep publisher = new RetrieveArtifactsBuildStep(null, names, "Development", null);
         assertEquals("Retrieve Artifact version for stage", ((RetrieveArtifactsBuildStep.DescriptorImpl)publisher.getDescriptor()).getDisplayName());
     }
 
@@ -193,7 +230,7 @@ public class RetrieveArtifactsBuildStepTest {
         name.setName("test-artifact");
         names.add(name);
 
-        RetrieveArtifactsBuildStep publisher = new RetrieveArtifactsBuildStep(names, "Development", null);
+        RetrieveArtifactsBuildStep publisher = new RetrieveArtifactsBuildStep(null, names, "Development", null);
         assertEquals("OK", ((RetrieveArtifactsBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckNames(names).kind.name());
         assertEquals("ERROR", ((RetrieveArtifactsBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckNames(new ArrayList<>()).kind.name());
         assertEquals("ERROR", ((RetrieveArtifactsBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckNames(null).kind.name());
@@ -207,7 +244,7 @@ public class RetrieveArtifactsBuildStepTest {
         name.setName("test-artifact");
         names.add(name);
 
-        RetrieveArtifactsBuildStep publisher = new RetrieveArtifactsBuildStep(names, "Development", null);
+        RetrieveArtifactsBuildStep publisher = new RetrieveArtifactsBuildStep(null, names, "Development", null);
         assertEquals("OK", ((RetrieveArtifactsBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckStage("Development").kind.name());
         assertEquals("ERROR", ((RetrieveArtifactsBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckStage("").kind.name());
         assertEquals("ERROR", ((RetrieveArtifactsBuildStep.DescriptorImpl)publisher.getDescriptor()).doCheckStage(null).kind.name());


### PR DESCRIPTION
We would like to have an ability to override the API token that is used to communicate with artifactz.io service, specified in plugin configuration, as part of the task in the pipeline.
Also, we increase verbosity of the error messages from the artifactz.io service.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ X] Ensure that the pull request title represents the desired changelog entry
- [ X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md
You can override it by creating .github/pull_request_template.md in your own repository
-->

